### PR TITLE
Add MNJ portfolio motif

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,8 +72,10 @@
 
     <header class="site-header">
       <a class="wordmark" href="#top" aria-label="MNJ, Marc-Andy Noel Jeune, home">
+        <span class="mnj-mark mnj-mark-header" aria-hidden="true">
+          <span>M</span><span>N</span><span>J</span>
+        </span>
         <span class="wordmark-full">Marc-Andy Noel Jeune</span>
-        <span class="wordmark-short" aria-hidden="true">MNJ</span>
       </a>
       <nav aria-label="Primary navigation">
         <a href="#work">Work</a>
@@ -105,7 +107,12 @@
         </div>
 
         <aside class="hero-evidence" aria-label="Career highlights">
-          <p class="evidence-label">What I bring</p>
+          <div class="evidence-top">
+            <p class="evidence-label">What I bring</p>
+            <span class="mnj-mark mnj-mark-inverse" aria-hidden="true">
+              <span>M</span><span>N</span><span>J</span>
+            </span>
+          </div>
           <div class="evidence-number">
             <strong>10</strong>
             <span>years building<br>production software</span>
@@ -505,7 +512,12 @@
     </main>
 
     <footer>
-      <p>© 2026 Marc-Andy Noel Jeune</p>
+      <div class="footer-identity">
+        <span class="mnj-mark mnj-mark-inverse" aria-hidden="true">
+          <span>M</span><span>N</span><span>J</span>
+        </span>
+        <p>© 2026 Marc-Andy Noel Jeune</p>
+      </div>
       <p>Built with semantic HTML, custom CSS, and careful restraint.</p>
     </footer>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -62,14 +62,49 @@ a {
 }
 
 .wordmark {
+  display: inline-flex;
+  gap: 0.75rem;
+  align-items: center;
   font-size: 0.88rem;
   font-weight: 800;
   text-decoration: none;
   letter-spacing: -0.025em;
 }
 
-.wordmark-short {
-  display: none;
+.mnj-mark {
+  display: inline-grid;
+  grid-template-columns: repeat(3, 1fr);
+  flex: 0 0 auto;
+  width: 3.35rem;
+  overflow: hidden;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid currentcolor;
+  box-shadow: 0.2rem 0.2rem 0 var(--accent);
+  transform: rotate(-2deg);
+}
+
+.mnj-mark > span {
+  display: grid;
+  aspect-ratio: 1;
+  place-items: center;
+  border-right: 1px solid currentcolor;
+  font-size: 0.58rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.mnj-mark > span:last-child {
+  border-right: 0;
+}
+
+.mnj-mark-header {
+  width: 3.1rem;
+}
+
+.mnj-mark-inverse {
+  color: var(--surface);
+  background: transparent;
 }
 
 nav {
@@ -235,6 +270,13 @@ h1 {
   box-shadow: 1rem 1rem 0 var(--accent);
 }
 
+.evidence-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .evidence-label {
   margin: 0;
   color: #cbc8be;
@@ -379,6 +421,19 @@ h2 {
   gap: 0.8rem;
   align-items: center;
   margin-bottom: 1.35rem;
+}
+
+.project-kicker::after {
+  margin-left: auto;
+  padding: 0.2rem 0.35rem;
+  color: var(--accent-dark);
+  border: 1px solid var(--accent-dark);
+  content: "MNJ";
+  font-size: 0.52rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  line-height: 1;
+  transform: rotate(-2deg);
 }
 
 .project-kicker span {
@@ -1020,6 +1075,16 @@ footer p {
   font-size: 0.72rem;
 }
 
+.footer-identity {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.footer-identity .mnj-mark {
+  width: 2.85rem;
+}
+
 .hero-copy,
 .hero-evidence {
   animation: reveal 650ms ease both;
@@ -1116,10 +1181,6 @@ footer p {
   nav a:nth-child(3),
   nav a:nth-child(4) {
     display: none;
-  }
-
-  .wordmark-short {
-    display: inline;
   }
 
   .hero {


### PR DESCRIPTION
## Summary

- Add a reusable three-cell MNJ typographic stamp.
- Repeat the motif in the header, hero evidence card, project labels, and footer.
- Preserve the existing orange, warm white, and black visual system.
- Keep the motif dependency-free with semantic HTML and custom CSS.

## Preview

Private preview: https://marcandy-portfolio-v4.marcandy-nj.chatgpt.site

Public preview: https://raw.githack.com/Marcandy/marcandy.github.io/038194402223af12a35c981f17f2294025efa727/index.html

## Verification

- Portfolio validation passes.
- No JavaScript or external library was added.